### PR TITLE
Fix small window buttons not clickable in screen corners unless cursor is directly over them

### DIFF
--- a/package/contents/ui/WindowControlButton.qml
+++ b/package/contents/ui/WindowControlButton.qml
@@ -93,6 +93,7 @@ Item {
     property int animationDuration: 100
     property int iconState: WindowControlButton.IconState.Active
     property bool mouseAreaEnabled: enabled
+    property int verticalPadding: 0
 
     Accessible.role: Accessible.Button
     Accessible.focusable: true
@@ -144,8 +145,8 @@ Item {
             required property int index
             required property var modelData
             anchors.fill: parent
-            anchors.topMargin: root.buttonMargins
-            anchors.bottomMargin: root.buttonMargins
+            anchors.topMargin: button.verticalPadding
+            anchors.bottomMargin: button.verticalPadding
             source: WCB.getButtonComponentSourcePath(button.iconTheme)
             onLoaded: function () {
                 let buttonComponent = item;

--- a/package/contents/ui/WindowControlButton.qml
+++ b/package/contents/ui/WindowControlButton.qml
@@ -144,8 +144,9 @@ Item {
             required property int index
             required property var modelData
             anchors.fill: parent
+            anchors.topMargin: root.buttonMargins
+            anchors.bottomMargin: root.buttonMargins
             source: WCB.getButtonComponentSourcePath(button.iconTheme)
-
             onLoaded: function () {
                 let buttonComponent = item;
                 let buttonState = index;

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -113,6 +113,7 @@ PlasmoidItem {
             Layout.alignment: root.widgetAlignment
             Layout.preferredWidth: root.buttonWidth
             Layout.preferredHeight: root.buttonHeight
+            verticalPadding: root.buttonMargins
             buttonType: modelData.windowControlButtonType
             themeName: plasmoid.configuration.widgetButtonsAuroraeTheme
             iconTheme: plasmoid.configuration.widgetButtonsIconsTheme

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -23,8 +23,8 @@ PlasmoidItem {
     property real widgetHeight: (vertical ? width : height)
     property real elementHeight: widgetHeight - plasmoid.configuration.widgetMargins * 2
     property real buttonMargins: plasmoid.configuration.widgetButtonsMargins
-    property real buttonHeight: elementHeight - buttonMargins * 2
-    property real buttonWidth: plasmoid.configuration.widgetButtonsAspectRatio / 100 * buttonHeight
+    property real buttonHeight: elementHeight
+    property real buttonWidth: (plasmoid.configuration.widgetButtonsAspectRatio) / 100 * (buttonHeight - buttonMargins * 2)
     property var widgetAlignment: plasmoid.configuration.widgetHorizontalAlignment | plasmoid.configuration.widgetVerticalAlignment
     property KWinConfig kWinConfig
     property bool widgetHovered: widgetHoverHandler.hovered
@@ -44,6 +44,7 @@ PlasmoidItem {
     onInvokeKWinShortcut: function (shortcut) {
         if (tasksModel.hasActiveWindow)
             tasksModel.activeWindow.actionCall(ActiveWindow.Action.Activate);
+
         kWinConfig.invokeKWinShortcut(shortcut);
     }
 
@@ -109,7 +110,6 @@ PlasmoidItem {
             id: windowControlButton
 
             property var modelData
-
             Layout.alignment: root.widgetAlignment
             Layout.preferredWidth: root.buttonWidth
             Layout.preferredHeight: root.buttonHeight


### PR DESCRIPTION
**Before**
Changing the button margins was affecting the height of the buttons, which made them unclickable at screen edges unless the cursor was directly over them.

![Before](https://imgur.com/B8uPGzu.gif)

**Now**
This has been fixed by applying margins around the buttons instead of altering their height. Buttons are now fully clickable, even in screen corners.

![After](https://imgur.com/dNDUwHn.gif)

@antroids 

Resolves #74 